### PR TITLE
Added code generator for RPC Types for Elixir/CSharp

### DIFF
--- a/rockem_dodgeball/.gitignore
+++ b/rockem_dodgeball/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 rockem_dodgeball-*.tar
 
+# Ignore generated types folder
+/generated/
+

--- a/rockem_dodgeball/config/types.rpc
+++ b/rockem_dodgeball/config/types.rpc
@@ -1,0 +1,85 @@
+struct BallData {
+    short ballId;
+    Vector3Data position;
+    QuaternionData rotation;
+    Vector3Data velocity;
+    short ricochetCount;
+    long lastThrownBy;
+    bool isLive;
+    short damagePoints;
+}
+
+struct GameData {
+    Team team1;
+    Team team2;
+    long timeLeft;
+    bool gameOver;
+}
+
+struct Team {
+    short teamId;
+    short score;
+}
+
+struct ClientMetadata {
+    long clientId;
+    short version;
+    long gameServerId;
+    long matchId;
+    long timestamp;
+}
+
+struct Vector3Data {
+    float x;
+    float y;
+    float z;
+}
+
+struct QuaternionData {
+    float x;
+    float y;
+    float z;
+    float w;
+}
+
+struct PlayerData {
+    long playerId;
+    short teamId;
+    string name;
+    Vector3Data position;
+    QuaternionData rotation;
+    Vector3Data velocity;
+    PlayerActionState actionState;
+    short ballCount;
+    PlayerHealthState healthState;
+}
+
+struct PlayerActionState {
+    bool isMoving;
+    bool isGrounded;
+    bool isWindingUp;
+    bool isHit;
+}
+
+struct PlayerHealthState {
+    short headHealth;
+    short leftArmHealth;
+    short rightArmHealth;
+    short chestHealth;
+    short abdomenHealth;
+    short leftLegHealth;
+    short rightLegHealth;
+}
+
+struct ClientGamestateUpdate {
+    ClientMetadata metadata;
+    PlayerData player;
+    BallData[] balls;
+}
+
+struct ServerGamestateUpdate {
+    long tickTimestamp;
+    GameData gameInfo;
+    PlayerData enemy;
+    BallData[] balls;
+}

--- a/rockem_dodgeball/lib/platform_scripts/type_generator.exs
+++ b/rockem_dodgeball/lib/platform_scripts/type_generator.exs
@@ -1,0 +1,11 @@
+defmodule TypeGenerator do
+  def read_in_types_file(types_file, csharp_outdir, elixir_outdir) do
+    TypeGenerator.Generators.read_in_types_file(types_file, csharp_outdir, elixir_outdir)
+  end
+end
+
+TypeGenerator.read_in_types_file(
+  "config/types.rpc",
+  "generated/types/csharp",
+  "generated/types/elixir"
+)

--- a/rockem_dodgeball/lib/platform_scripts/type_generator/generators.ex
+++ b/rockem_dodgeball/lib/platform_scripts/type_generator/generators.ex
@@ -1,0 +1,106 @@
+defmodule TypeGenerator.Generators do
+  alias TypeGenerator.{
+    Generators
+  }
+
+  @primitive_types MapSet.new([
+                     "short",
+                     "int",
+                     "long",
+                     "bool",
+                     "float",
+                     "double",
+                     "string"
+                   ])
+
+  def primitive_type?(field_type) do
+    MapSet.member?(@primitive_types, field_type)
+  end
+
+  def custom_type?(field_type, custom_types) do
+    Map.has_key?(custom_types, field_type)
+  end
+
+  def bad_typecheck([field_type, field_name]) do
+    IO.puts("Type check failed for field #{field_name} of type #{field_type}")
+    System.stop(1)
+  end
+
+  def check_type([field_type, _field_name] = field, custom_types) do
+    case {primitive_type?(field_type), custom_type?(field_type, custom_types)} do
+      {false, false} -> bad_typecheck(field)
+      {true, _} -> true
+      {_, true} -> true
+    end
+  end
+
+  def type_checked?(fields, custom_types) do
+    checked_results = Enum.filter(fields, &check_type(&1, custom_types))
+    length(fields) == length(checked_results)
+  end
+
+  def parse_fields(raw_fields) do
+    raw_fields
+    |> String.replace(~r/;|\n/, "")
+    |> String.split("    ")
+    |> Enum.filter(&(&1 != ""))
+    |> Enum.map(&String.split(&1, " "))
+  end
+
+  def parse_struct(struct_text, {custom_types, all_field_types}) do
+    struct_text = String.trim(struct_text, " ")
+
+    regex = ~r/(?<type_name>[A-Za-z\d]+) {(?<fields>[\sA-Za-z;\d\[\]]+)}[\s]+/
+    captures = Regex.named_captures(regex, struct_text)
+
+    %{
+      "type_name" => type_name,
+      "fields" => raw_fields
+    } = captures
+
+    # Parse fields
+    fields = parse_fields(raw_fields)
+
+    # Add field type to types we've seen (for typechecking later)
+    all_field_types =
+      fields
+      |> Enum.reduce(all_field_types, &MapSet.put(&2, &1))
+
+    # Update custom types with new type definition
+    custom_types = custom_types |> Map.put_new(type_name, fields)
+
+    {custom_types, all_field_types}
+  end
+
+  def read_in_types_file(filepath, csharp_outdir, elixir_outdir) do
+    {:ok, contents} = File.read(filepath)
+
+    {custom_types, all_field_types} =
+      contents
+      |> String.split("struct ", trim: true)
+      |> Enum.reduce({%{}, MapSet.new()}, &parse_struct(&1, &2))
+
+    # Type check each unique field type encountered
+    all_field_types
+    |> Enum.map(fn [field_type, field_name] ->
+      # Handle array data type
+      field_type =
+        if String.ends_with?(field_type, "[]") do
+          String.slice(field_type, 0..(String.length(field_type) - 3))
+        else
+          field_type
+        end
+
+      [field_type, field_name]
+    end)
+    |> Enum.each(&check_type(&1, custom_types))
+
+    # If program has not exited early during type check, generate files
+    generate_type_files(custom_types, csharp_outdir, elixir_outdir)
+  end
+
+  def generate_type_files(custom_types, csharp_outdir, elixir_outdir) do
+    Generators.CSharp.gen_csharp_types(custom_types, csharp_outdir)
+    Generators.Elixir.gen_elixir_types(custom_types, elixir_outdir)
+  end
+end

--- a/rockem_dodgeball/lib/platform_scripts/type_generator/generators/csharp.ex
+++ b/rockem_dodgeball/lib/platform_scripts/type_generator/generators/csharp.ex
@@ -1,0 +1,24 @@
+defmodule TypeGenerator.Generators.CSharp do
+  def gen_csharp_types(types_map, outdir) do
+    types_map
+    |> Map.keys()
+    |> Enum.map(&new_csharp_classtype(&1, Map.get(types_map, &1), outdir))
+  end
+
+  def new_classtype_field([field_type, field_name]) do
+    "    public #{field_type} #{field_name};"
+  end
+
+  def new_csharp_classtype(type_name, fields, outdir) do
+    classtype =
+      "public class #{type_name}\n{\n" <>
+        (fields
+         |> Enum.map(&new_classtype_field(&1))
+         |> Enum.join("\n")) <>
+        "\n}\n"
+
+    {:ok, file} = File.open(outdir <> "/" <> type_name <> ".cs", [:write])
+    IO.binwrite(file, classtype)
+    File.close(file)
+  end
+end

--- a/rockem_dodgeball/lib/platform_scripts/type_generator/generators/elixir.ex
+++ b/rockem_dodgeball/lib/platform_scripts/type_generator/generators/elixir.ex
@@ -1,0 +1,25 @@
+defmodule TypeGenerator.Generators.Elixir do
+  def gen_elixir_types(types_map, outdir) do
+    types_map
+    |> Map.keys()
+    |> Enum.map(&new_elixir_struct(&1, Map.get(types_map, &1), outdir))
+  end
+
+  def new_struct_field([field_type, field_name]) do
+    "    #{field_name}: nil, # #{field_type}"
+  end
+
+  def new_elixir_struct(type_name, fields, outdir) do
+    classtype =
+      "defmodule #{type_name} do\n\n" <>
+        "  defstruct(\n" <>
+        (fields
+         |> Enum.map(&new_struct_field(&1))
+         |> Enum.join("\n")) <>
+        "\n  )\n\nend\n"
+
+    {:ok, file} = File.open(outdir <> "/" <> type_name <> ".ex", [:write])
+    IO.binwrite(file, classtype)
+    File.close(file)
+  end
+end

--- a/rockem_dodgeball/lib/utils/transport.ex
+++ b/rockem_dodgeball/lib/utils/transport.ex
@@ -48,7 +48,6 @@ defmodule Utils.Transport do
     {raw_vector3, raw_quaternion} = split_binary_at_index(binary, 12)
     vector3 = read_vector3(raw_vector3)
     quaternion = read_quaternion(raw_quaternion)
-    {vector3, quaternion} |> inspect |> IO.puts()
     {vector3, quaternion}
   end
 end

--- a/rockem_dodgeball/test/platform_scripts/type_generator/generators_test.exs
+++ b/rockem_dodgeball/test/platform_scripts/type_generator/generators_test.exs
@@ -1,0 +1,136 @@
+defmodule TypeGenerator.GeneratorsTest do
+  use ExUnit.Case
+  doctest TypeGenerator.Generators
+
+  @types_file "test/fake_types.rpc"
+  @csharp_outdir "test/tmp_csharp_outdir/"
+  @elixir_outdir "test/tmp_elixir_outdir/"
+
+  setup_all do
+    # Cleanup any stale files/directories before test
+    case File.exists?(@types_file) do
+      true -> File.rm!(@types_file)
+      _false -> :ok
+    end
+
+    case File.exists?(@csharp_outdir) do
+      true -> File.rm_rf!(@csharp_outdir)
+      _false -> :ok
+    end
+
+    case File.exists?(@elixir_outdir) do
+      true -> File.rm_rf!(@elixir_outdir)
+      _false -> :ok
+    end
+  end
+
+  setup do
+    # Create test directories before each
+    File.mkdir!(@csharp_outdir)
+    File.mkdir!(@elixir_outdir)
+
+    # Cleanup generated files and directories after each
+    on_exit(fn ->
+      File.rm_rf!(@csharp_outdir)
+      File.rm_rf!(@elixir_outdir)
+
+      case File.exists?(@types_file) do
+        true -> File.rm!(@types_file)
+        _false -> :ok
+      end
+    end)
+  end
+
+  test "properly generates csharp and elixir types" do
+    # create fake file
+    valid_types_text = """
+    struct Foo {
+        short field1;
+        Bar field2;
+        Zoo[] field3;
+        string[] field4;
+    }
+    struct Bar {
+        long field1;
+    }
+    struct Zoo {
+        int anotherField;
+    }
+    """
+
+    expected_foo_cs = """
+    public class Foo
+    {
+        public short field1;
+        public Bar field2;
+        public Zoo[] field3;
+        public string[] field4;
+    }
+    """
+
+    expected_bar_cs = """
+    public class Bar
+    {
+        public long field1;
+    }
+    """
+
+    expected_zoo_cs = """
+    public class Zoo
+    {
+        public int anotherField;
+    }
+    """
+
+    expected_foo_ex = """
+    defmodule Foo do
+
+      defstruct(
+        field1: nil, # short
+        field2: nil, # Bar
+        field3: nil, # Zoo[]
+        field4: nil, # string[]
+      )
+
+    end
+    """
+
+    expected_bar_ex = """
+    defmodule Bar do
+
+      defstruct(
+        field1: nil, # long
+      )
+
+    end
+    """
+
+    expected_zoo_ex = """
+    defmodule Zoo do
+
+      defstruct(
+        anotherField: nil, # int
+      )
+
+    end
+    """
+
+    {:ok, file} = File.open(@types_file, [:write])
+    IO.binwrite(file, valid_types_text)
+    File.close(file)
+
+    TypeGenerator.Generators.read_in_types_file(
+      @types_file,
+      @csharp_outdir,
+      @elixir_outdir
+    )
+
+    assert expected_foo_cs == File.read!(@csharp_outdir <> "Foo.cs")
+    assert expected_bar_cs == File.read!(@csharp_outdir <> "Bar.cs")
+    assert expected_zoo_cs == File.read!(@csharp_outdir <> "Zoo.cs")
+
+    assert expected_foo_ex == File.read!(@elixir_outdir <> "Foo.ex")
+    assert expected_bar_ex == File.read!(@elixir_outdir <> "Bar.ex")
+    assert expected_zoo_ex == File.read!(@elixir_outdir <> "Zoo.ex")
+  end
+end


### PR DESCRIPTION
Will allow for easier syncing on types across server/client.
- Generates type classes from thrift-like source file (types.rpc)
- Generates elixir types using `defstruct` (one per file)
- Generates CSharp types using classes (one per file)